### PR TITLE
Removes mongod from components

### DIFF
--- a/config/cli.modules.d/foreman_admin_logging_katello.yml
+++ b/config/cli.modules.d/foreman_admin_logging_katello.yml
@@ -7,19 +7,6 @@
   :logging:
     :component:
       -
-        :name: mongod
-        :friendly_name: MondoDB
-        :file: /etc/mongod.conf
-        :destinations: "syslog"
-        :debug:
-          -
-            :action: ensure_line_is_present
-            :line: ["systemLog.verbosity", "=", "3"]
-        :production:
-          -
-            :action: ensure_line_is_present
-            :line: ["systemLog.verbosity", "=", "0"]
-      -
         :name: qpidd
         :friendly_name: QPID broker
         :file: /etc/qpid/qpidd.conf


### PR DESCRIPTION
It looks the current setting does not work with Mongo from RHEL7. I think
adding Mongo to Foreman Debug tool was an overkill, we unlikely will be
investigating bugs in Mongo itself, we usually need to increase verbosity of
Pulp processes and that's it. For this reason, I recommend simply to disable
it.

https://bugzilla.redhat.com/show_bug.cgi?id=1305085

@ehelms ?
