### PR TITLE
Fixes #22451 - Fixed dry-run command

### DIFF
--- a/lib/hammer_cli_foreman_admin/logging_command.rb
+++ b/lib/hammer_cli_foreman_admin/logging_command.rb
@@ -96,9 +96,9 @@ module HammerCLIForemanAdmin
             action[:file] = file
           end
           func = action_functions[action_name.to_sym]
-          if func && ! option_dry_run?
+          if func
             logger.info "Processing #{name} action #{action_name}"
-            func.call(action)
+            func.call(action) unless option_dry_run?
           else
             raise "Unknown action #{action_name} for component #{name}"
           end


### PR DESCRIPTION
That never worked, when `-n` was filed, it was always erroring out with:

    Error: Unknown action ensure_line_is_present for component postgresql

This fixes it.